### PR TITLE
fix: prevent disk exhaustion with log rotation and image pruning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,12 @@ jobs:
             echo "No services need to be updated"
           fi
 
+      - name: Prune old Docker images
+        run: |
+          gcloud compute ssh ${{ secrets.GCP_VM_NAME }} --zone=${{ secrets.GCP_ZONE }} \
+            --command="sudo docker image prune -af --filter 'until=48h'" \
+            --ssh-key-expire-after=1m
+
       - name: Invalidate stats timestamp if config data changed
         if: steps.changes.outputs.config_data == 'true'
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     read_only: true # Make the container filesystem read-only (optional but recommended)
     cap_drop: [all] # Drop all Linux capabilities (optional but recommended)
     security_opt: [no-new-privileges:true] # Another protection to restrict superuser privileges (optional but recommended)
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       - DOMAINS=csbatagi.com,db2.csbatagi.com # Comma-separated list of domains to update
       - PROXIED=false # Tell Cloudflare to cache webpages and hide your IP (optional)
@@ -32,9 +37,14 @@ services:
   #     - /srv/mysql:/var/lib/mysql
 
   backend:
-    restart: unless-stopped 
+    restart: unless-stopped
     image: ghcr.io/csbatagi/monorepo/backend:latest  # Using the image from GitHub Container Registry with main branch tag
     pull_policy: always  # Force Docker to pull the latest image every time
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       DB_HOST: postgres # Hostname matches the service name below
       DB_DATABASE: csdm
@@ -58,9 +68,14 @@ services:
       - postgres  # Ensure the database is started before backend
 
   frontend-nextjs:
-    restart: unless-stopped 
+    restart: unless-stopped
     image: ghcr.io/csbatagi/monorepo/frontend-nextjs:latest  # Using the image from GitHub Container Registry
     pull_policy: always  # Force Docker to pull the latest image every time
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - db2
     expose:
@@ -76,7 +91,12 @@ services:
 
   postgres:
     image: postgres:17  # Match existing data format (was auto-upgraded)
-    restart: unless-stopped 
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # NOTE: No host port mapping — backend accesses Postgres via Docker network (hostname: postgres).
     # The port was previously exposed (5432:5432) which is a security risk on production.
     # For local dev DB access, use docker-compose.local.yml instead.
@@ -89,9 +109,14 @@ services:
      - /srv/pgdata:/var/lib/postgresql/data
 
   caddy:
-    image: caddy:latest 
+    image: caddy:latest
     container_name: caddy-reverse-proxy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - db2 
     volumes:


### PR DESCRIPTION
## Summary
- VM was becoming unresponsive due to disk filling to 94% (27G/29G)
- Root causes: dangling Docker images (14GB), unbounded container logs, uncapped journald (2.7GB)
- Add `logging` config (10MB max, 3 rotated files) to all 5 services in `docker-compose.yml`
- Add `docker image prune` step to deploy workflow to clean images older than 48h after each deploy

## Already applied on VM (one-time)
- Phase 1 cleanup reclaimed ~17.4GB (disk went from 94% → 35%)
- Journald capped to 200MB via `/etc/systemd/journald.conf.d/size-limit.conf`

## Test plan
- [ ] Verify `docker compose config` parses correctly with new logging fields
- [ ] Deploy and confirm containers start with log rotation enabled
- [ ] Verify deploy workflow prunes old images after pulling new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)