### PR TITLE
fix(pwa): keep installed app fresh and add pull-to-refresh

### DIFF
--- a/frontend-nextjs/src/app/globals.css
+++ b/frontend-nextjs/src/app/globals.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ===== Pull-to-refresh ===== */
+/* Suppress the browser's native pull-to-refresh / scroll-chaining so the
+   custom PullToRefresh gesture is the single source of truth on every platform. */
+html,
+body {
+  overscroll-behavior-y: contain;
+}
+
+@keyframes ptr-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* ===== Dark Mode Color Tokens (CSS Custom Properties) ===== */
 /* Single source of truth — update here to change everywhere */
 :root {

--- a/frontend-nextjs/src/components/Providers.tsx
+++ b/frontend-nextjs/src/components/Providers.tsx
@@ -7,6 +7,7 @@ import { SessionProvider } from "@/contexts/SessionContext";
 import AdminStatsButton from "@/components/AdminStatsButton";
 import { NotificationProvider } from "@/contexts/NotificationContext";
 import AutoPushRegistration from "@/components/AutoPushRegistration";
+import PullToRefresh from "@/components/PullToRefresh";
 
 export default function Providers({ children }: { children: ReactNode }) {
   const content = (
@@ -20,6 +21,7 @@ export default function Providers({ children }: { children: ReactNode }) {
       <SessionProvider>
         <NotificationProvider>
           <AutoPushRegistration />
+          <PullToRefresh />
           <Layout>
             {content}
             <AdminStatsButton />

--- a/frontend-nextjs/src/components/PullToRefresh.tsx
+++ b/frontend-nextjs/src/components/PullToRefresh.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+
+// Pull distance (px, after resistance) needed to trigger a refresh.
+const TRIGGER_DISTANCE = 70;
+// Cap on how far the indicator travels so a long drag doesn't run off-screen.
+const MAX_PULL = 110;
+// Finger travel is damped by this factor so the pull feels weighty, not 1:1.
+const RESISTANCE = 0.5;
+
+/**
+ * Custom pull-to-refresh for the installed PWA.
+ *
+ * iOS standalone PWAs have no browser chrome and therefore no native
+ * pull-to-refresh at all; on Android the native gesture is suppressed via
+ * `overscroll-behavior-y: contain` (globals.css) so behaviour is identical on
+ * both. A pull from the top past the threshold reloads the document, which
+ * re-runs SSR and remounts every client with fresh data.
+ */
+export default function PullToRefresh() {
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Refs mirror state for use inside the (once-registered) touch handlers,
+  // avoiding re-binding listeners on every drag frame.
+  const pullRef = useRef(0);
+  const refreshingRef = useRef(false);
+  const startY = useRef<number | null>(null);
+  const dragging = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const atTop = () =>
+      (window.scrollY || document.documentElement.scrollTop || 0) <= 0;
+
+    const setPullVal = (v: number) => {
+      pullRef.current = v;
+      setPull(v);
+    };
+
+    const onStart = (e: TouchEvent) => {
+      if (refreshingRef.current || e.touches.length !== 1 || !atTop()) {
+        startY.current = null;
+        return;
+      }
+      startY.current = e.touches[0].clientY;
+      dragging.current = false;
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (refreshingRef.current || startY.current === null) return;
+      const dy = e.touches[0].clientY - startY.current;
+      if (dy <= 0) {
+        if (dragging.current) {
+          dragging.current = false;
+          setPullVal(0);
+        }
+        return;
+      }
+      if (!atTop()) {
+        startY.current = null;
+        if (dragging.current) {
+          dragging.current = false;
+          setPullVal(0);
+        }
+        return;
+      }
+      dragging.current = true;
+      setPullVal(Math.min(MAX_PULL, dy * RESISTANCE));
+      // Suppress native overscroll/bounce while we own the gesture.
+      if (e.cancelable) e.preventDefault();
+    };
+
+    const onEnd = () => {
+      if (refreshingRef.current) return;
+      if (dragging.current && pullRef.current >= TRIGGER_DISTANCE) {
+        refreshingRef.current = true;
+        setRefreshing(true);
+        setPullVal(TRIGGER_DISTANCE);
+        // Let the spinner paint before the synchronous reload tears down the page.
+        window.setTimeout(() => window.location.reload(), 150);
+      } else {
+        setPullVal(0);
+      }
+      startY.current = null;
+      dragging.current = false;
+    };
+
+    window.addEventListener('touchstart', onStart, { passive: true });
+    window.addEventListener('touchmove', onMove, { passive: false });
+    window.addEventListener('touchend', onEnd, { passive: true });
+    window.addEventListener('touchcancel', onEnd, { passive: true });
+
+    return () => {
+      window.removeEventListener('touchstart', onStart);
+      window.removeEventListener('touchmove', onMove);
+      window.removeEventListener('touchend', onEnd);
+      window.removeEventListener('touchcancel', onEnd);
+    };
+  }, []);
+
+  const visible = pull > 0 || refreshing;
+  const progress = Math.min(1, pull / TRIGGER_DISTANCE);
+  const offset = (refreshing ? TRIGGER_DISTANCE : pull) - 44;
+
+  return (
+    <div
+      aria-hidden={!visible}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        display: 'flex',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        zIndex: 60,
+        opacity: visible ? 1 : 0,
+        transform: `translateY(${offset}px)`,
+        transition: dragging.current ? 'none' : 'transform 0.2s ease, opacity 0.2s ease',
+      }}
+    >
+      <div
+        style={{
+          marginTop: 'calc(8px + env(safe-area-inset-top, 0px))',
+          width: 36,
+          height: 36,
+          borderRadius: '9999px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'rgba(37, 99, 235, 0.95)',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.25)',
+        }}
+      >
+        <RefreshCw
+          size={20}
+          color="#ffffff"
+          style={{
+            transform: `rotate(${progress * 270}deg)`,
+            animation: refreshing ? 'ptr-spin 0.8s linear infinite' : 'none',
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend-nextjs/src/lib/useStatsRefresh.ts
+++ b/frontend-nextjs/src/lib/useStatsRefresh.ts
@@ -15,6 +15,13 @@ interface UseStatsRefreshOptions {
   refreshOnResume?: boolean;
   /** Minimum time between foreground-triggered checks for the same key set. Default: 30s. */
   minIntervalMs?: number;
+  /**
+   * Background poll cadence while the page is visible. Installed PWAs keep a
+   * single document alive for the whole session, so without this an open page
+   * only ever refreshes on resume events — which iOS standalone apps fire
+   * unreliably. Set to 0/null to disable. Default: 90s.
+   */
+  pollIntervalMs?: number | null;
   /** Dataset keys this client can consume. The global stats version still controls freshness. */
   keys?: string[];
 }
@@ -33,6 +40,7 @@ export function useStatsRefresh({
   checkOnMount,
   refreshOnResume = true,
   minIntervalMs = 30_000,
+  pollIntervalMs = 90_000,
   keys = [],
 }: UseStatsRefreshOptions) {
   const onDataRef = useRef(onData);
@@ -53,6 +61,9 @@ export function useStatsRefresh({
 
     let cancelled = false;
     let inFlight = false;
+    // Coalesces the burst of resume events (visibilitychange + focus + pageshow
+    // often fire together) so a single return-to-foreground triggers one check.
+    let lastForcedAt = 0;
     const refreshKey = keyParam || 'all';
 
     async function checkForStatsUpdate(force = false) {
@@ -60,8 +71,13 @@ export function useStatsRefresh({
       if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
 
       const now = Date.now();
-      const lastAttempt = lastRefreshAttemptByKey.get(refreshKey) || 0;
-      if (!force && now - lastAttempt < minIntervalMs) return;
+      if (force) {
+        if (now - lastForcedAt < 3_000) return;
+        lastForcedAt = now;
+      } else {
+        const lastAttempt = lastRefreshAttemptByKey.get(refreshKey) || 0;
+        if (now - lastAttempt < minIntervalMs) return;
+      }
 
       lastRefreshAttemptByKey.set(refreshKey, now);
       inFlight = true;
@@ -100,18 +116,45 @@ export function useStatsRefresh({
       void checkForStatsUpdate(true);
     }
 
-    if (!refreshOnResume) {
-      return () => { cancelled = true; };
+    // Background poll keeps an already-open page fresh without a resume event.
+    // Throttled (force=false) so it never beats minIntervalMs, and paused while
+    // the page is hidden so a backgrounded PWA does no network work.
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    const startPolling = () => {
+      if (pollTimer || !pollIntervalMs) return;
+      pollTimer = setInterval(() => {
+        if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+          void checkForStatsUpdate();
+        }
+      }, pollIntervalMs);
+    };
+    const stopPolling = () => {
+      if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    };
+
+    if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+      startPolling();
     }
 
+    if (!refreshOnResume) {
+      return () => { cancelled = true; stopPolling(); };
+    }
+
+    // Force on resume so the 30s throttle can't swallow the one check that
+    // matters most — the user just brought the app back to the foreground.
     const handleVisible = () => {
-      if (document.visibilityState === 'visible') void checkForStatsUpdate();
+      if (document.visibilityState === 'visible') {
+        void checkForStatsUpdate(true);
+        startPolling();
+      } else {
+        stopPolling();
+      }
     };
     const handleFocus = () => {
-      void checkForStatsUpdate();
+      void checkForStatsUpdate(true);
     };
     const handlePageShow = () => {
-      void checkForStatsUpdate();
+      void checkForStatsUpdate(true);
     };
 
     document.addEventListener('visibilitychange', handleVisible);
@@ -120,9 +163,10 @@ export function useStatsRefresh({
 
     return () => {
       cancelled = true;
+      stopPolling();
       document.removeEventListener('visibilitychange', handleVisible);
       window.removeEventListener('focus', handleFocus);
       window.removeEventListener('pageshow', handlePageShow);
     };
-  }, [enabled, keyParam, minIntervalMs, refreshOnResume, shouldCheckOnMount]);
+  }, [enabled, keyParam, minIntervalMs, pollIntervalMs, refreshOnResume, shouldCheckOnMount]);
 }


### PR DESCRIPTION
The installed PWA only refreshed an open stats page on resume events
(visibilitychange/focus/pageshow), which iOS standalone apps fire
unreliably — so users had to close and reopen the app to see new stats.
There was also no way to manually reload, since standalone PWAs have no
native pull-to-refresh on iOS.

- useStatsRefresh: add a visibility-aware background poll (default 90s,
  paused while hidden, throttled by minIntervalMs so it never hammers the
  backend) and force the check on resume so the 30s throttle can't swallow
  the one check that matters. Resume events are coalesced to avoid the
  duplicate-fire burst.
- Add a custom PullToRefresh component (mounted in Providers) that works
  on iOS and Android; native overscroll/refresh is suppressed via
  overscroll-behavior-y: contain so the gesture is consistent everywhere.

Both changes are low-memory and respect the existing /api/stats/check
cooldown + in-flight dedupe, so they add negligible load on the 1 GB VM.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nj9p3yLBHmUqNHbGgve7Au